### PR TITLE
Fix for bcdata v0.4.0

### DIFF
--- a/R/create_base_vectors.R
+++ b/R/create_base_vectors.R
@@ -266,7 +266,7 @@ get_roads <- function(in_aoi, out_path) {
 
   message("\rDownloading Road network")
   roads <- bcdc_query_geodata("bb060417-b6e6-4548-b837-f9060d94743e") %>%
-    bcdata::filter(BBOX(st_bbox(in_aoi))) %>% # slightly larger extent
+    bcdata::filter(BBOX(local(st_bbox(in_aoi)))) %>% # slightly larger extent
     bcdata::select(id, ROAD_NAME_FULL, ROAD_CLASS, ROAD_SURFACE, FEATURE_LENGTH_M) %>%
     collect() %>%
     dplyr::select(id, ROAD_NAME_FULL,ROAD_SURFACE, ROAD_CLASS,FEATURE_LENGTH_M) %>%
@@ -277,7 +277,7 @@ get_roads <- function(in_aoi, out_path) {
 
   fsr <- bcdc_query_geodata("9e5bfa62-2339-445e-bf67-81657180c682") %>%
     bcdata::filter(
-      BBOX(st_bbox(in_aoi))) %>%
+      BBOX(local(st_bbox(in_aoi)))) %>%
     collect() %>%
     dplyr::select(id, FILE_TYPE_DESCRIPTION, FEATURE_LENGTH_M) %>%
     dplyr::rename(ROAD_CLASS = FILE_TYPE_DESCRIPTION) %>%


### PR DESCRIPTION
This is a fix due to a change in `bcdata` as of v0.4.0, From the [NEWS](https://github.com/bcgov/bcdata/blob/v0.4.0/NEWS.md):

* For WFS queries constructed using `bcdc_query_geodata()`, function calls in `filter()` that need to be evaluated locally are no-longer auto-detected. They now need to be wrapped in `local()` to force local evaluation before the `CQL` query is constructed and sent to the WFS server. Please see [`vignette("local-filter")`](https://bcgov.github.io/bcdata/articles/local-filter.html) for more information. This aligns with recommended usage patterns in other `dbplyr` backends (#304, PR #305).